### PR TITLE
Update xdrv_04_light_artnet.ino

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
@@ -197,11 +197,13 @@ void ArtNetProcessPacket(uint8_t * buf, size_t len) {
     uint8_t r8 = buf[idx+1];
     uint8_t g8 = buf[idx];
     uint8_t b8 = buf[idx+2];
+    uint8_t w8 = buf[idx+3];
     uint16_t dimmer10 = changeUIntScale(artnet_conf.dimm, 0, 100, 0, 1023);
     uint16_t color[LST_MAX] = {0};
     color[0] = changeUIntScale(r8, 0, 255, 0, dimmer10);
     color[1] = changeUIntScale(g8, 0, 255, 0, dimmer10);
     color[2] = changeUIntScale(b8, 0, 255, 0, dimmer10);
+    color[3] = changeUIntScale(w8, 0, 255, 0, dimmer10);
     // AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DMX: %02X-%02X-%02X univ=%i rows=%i max_univ=%i"), buf[idx+1], buf[idx], buf[idx+2], universe, row, artnet_conf.univ + artnet_conf.rows);
     LightSetOutputs(color);
   }


### PR DESCRIPTION
ArtNet DMX - Add RGBWW support for single light and respect RGBWWTable values

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
